### PR TITLE
enable server_address and disable example commands in nrpe.cfg template

### DIFF
--- a/templates/nrpe.cfg.j2
+++ b/templates/nrpe.cfg.j2
@@ -1,7 +1,7 @@
 #############################################################################
-# Sample NRPE Config File 
+# Sample NRPE Config File
 # Written by: Ethan Galstad (nagios@nagios.org)
-# 
+#
 # Last Modified: 11-23-2007
 #
 # NOTES:
@@ -34,28 +34,28 @@ server_port={{ nagios_nrpe_server_port }}
 # and you do not want nrpe to bind on all interfaces.
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
-#server_address={{ nagios_nrpe_server_bind_address }}
+server_address={{ nagios_nrpe_server_bind_address }}
 
 # NRPE USER
-# This determines the effective user that the NRPE daemon should run as.  
+# This determines the effective user that the NRPE daemon should run as.
 # You can either supply a username or a UID.
-# 
+#
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
 nrpe_user={{ nagios_nrpe_server_user }}
 
 # NRPE GROUP
-# This determines the effective group that the NRPE daemon should run as.  
+# This determines the effective group that the NRPE daemon should run as.
 # You can either supply a group name or a GID.
-# 
+#
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
 nrpe_group={{ nagios_nrpe_server_group }}
 
 # ALLOWED HOST ADDRESSES
-# This is an optional comma-delimited list of IP address or hostnames 
+# This is an optional comma-delimited list of IP address or hostnames
 # that are allowed to talk to the NRPE daemon. Network addresses with a bit mask
-# (i.e. 192.168.1.0/24) are also supported. Hostname wildcards are not currently 
+# (i.e. 192.168.1.0/24) are also supported. Hostname wildcards are not currently
 # supported.
 #
 # Note: The daemon only does rudimentary checking of the client's IP
@@ -71,9 +71,9 @@ allowed_hosts={{ nagios_nrpe_server_allowed_hosts|join(',') }}
 # This option determines whether or not the NRPE daemon will allow clients
 # to specify arguments to commands that are executed.  This option only works
 # if the daemon was configured with the --enable-command-args configure script
-# option.  
+# option.
 #
-# *** ENABLING THIS OPTION IS A SECURITY RISK! *** 
+# *** ENABLING THIS OPTION IS A SECURITY RISK! ***
 # Read the SECURITY file for information on some of the security implications
 # of enabling this variable.
 #
@@ -84,15 +84,15 @@ dont_blame_nrpe={{ nagios_nrpe_server_dont_blame_nrpe }}
 # BASH COMMAND SUBTITUTION
 # This option determines whether or not the NRPE daemon will allow clients
 # to specify arguments that contain bash command substitutions of the form
-# $(...).  This option only works if the daemon was configured with both 
-# the --enable-command-args and --enable-bash-command-substitution configure 
+# $(...).  This option only works if the daemon was configured with both
+# the --enable-command-args and --enable-bash-command-substitution configure
 # script options.
 #
-# *** ENABLING THIS OPTION IS A HIGH SECURITY RISK! *** 
+# *** ENABLING THIS OPTION IS A HIGH SECURITY RISK! ***
 # Read the SECURITY file for information on some of the security implications
 # of enabling this variable.
 #
-# Values: 0=do not allow bash command substitutions, 
+# Values: 0=do not allow bash command substitutions,
 #         1=allow bash command substitutions
 
 allow_bash_command_substitution=0
@@ -103,9 +103,9 @@ allow_bash_command_substitution=0
 # command line from the command definition.
 #
 # *** THIS EXAMPLE MAY POSE A POTENTIAL SECURITY RISK, SO USE WITH CAUTION! ***
-# Usage scenario: 
+# Usage scenario:
 # Execute restricted commmands using sudo.  For this to work, you need to add
-# the nagios user to your /etc/sudoers.  An example entry for alllowing 
+# the nagios user to your /etc/sudoers.  An example entry for alllowing
 # execution of the plugins from might be:
 #
 # nagios          ALL=(ALL) NOPASSWD: /usr/lib/nagios/plugins/
@@ -114,7 +114,7 @@ allow_bash_command_substitution=0
 # without asking for a password.  If you do this, make sure you don't give
 # random users write access to that directory or its contents!
 
-# command_prefix=/usr/bin/sudo 
+# command_prefix=/usr/bin/sudo
 
 # DEBUGGING OPTION
 # This option determines whether or not debugging messages are logged to the
@@ -182,14 +182,14 @@ connection_timeout=300
 
 # The following examples use hardcoded command arguments...
 
-command[check_users]={{ nagios_nrpe_server_plugins_dir }}/check_users -w 5 -c 10
-command[check_load]={{ nagios_nrpe_server_plugins_dir }}/check_load -w 15,10,5 -c 30,25,20
-command[check_hda1]={{ nagios_nrpe_server_plugins_dir }}/check_disk -w 20% -c 10% -p /dev/hda1
-command[check_zombie_procs]={{ nagios_nrpe_server_plugins_dir }}/check_procs -w 5 -c 10 -s Z
-command[check_total_procs]={{ nagios_nrpe_server_plugins_dir }}/check_procs -w 150 -c 200 
+#command[check_users]={{ nagios_nrpe_server_plugins_dir }}/check_users -w 5 -c 10
+#command[check_load]={{ nagios_nrpe_server_plugins_dir }}/check_load -w 15,10,5 -c 30,25,20
+#command[check_hda1]={{ nagios_nrpe_server_plugins_dir }}/check_disk -w 20% -c 10% -p /dev/hda1
+#command[check_zombie_procs]={{ nagios_nrpe_server_plugins_dir }}/check_procs -w 5 -c 10 -s Z
+#command[check_total_procs]={{ nagios_nrpe_server_plugins_dir }}/check_procs -w 150 -c 200
 
 # The following examples allow user-supplied arguments and can
-# only be used if the NRPE daemon was compiled with support for 
+# only be used if the NRPE daemon was compiled with support for
 # command arguments *AND* the dont_blame_nrpe directive in this
 # config file is set to '1'.  This poses a potential security risk, so
 # make sure you read the SECURITY file before doing this.
@@ -208,7 +208,7 @@ include={{ nagios_nrpe_server_dir }}/nrpe_local.cfg
 include={{ nagios_nrpe_server_dir }}/nrpe_ansible.cfg
 
 {% if 'ansible_os_family' != 'Archlinux' %}
-# 
+#
 # you can place your config snipplets into nrpe.d/
 # only snipplets ending in .cfg will get included
 include_dir={{ nagios_nrpe_server_dir }}/nrpe.d/


### PR DESCRIPTION
It makes sense to actually enable the server_address in the nrpe.cfg, otherwise the var for it does not have any effect. There is no need for the example commands being enabled by default in the template.
