### PR TITLE
Allow variable override to work with OS defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ nagios_nrpe_server_bind_address: 127.0.0.1
 nagios_nrpe_server_port: 5666
 nagios_nrpe_server_allowed_hosts: 127.0.0.1
 nagios_nrpe_server_dont_blame_nrpe: 0
+nagios_nrpe_server_plugins_src_dir: plugins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,12 +3,7 @@
 
 # Include variables at the start so they're in scope
 - name: Include OS-Specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
-
-# Include RedHat specific variables due to x64/x86 differences
-- name: Include RedHat architecture specific variables
-  include_vars: "{{ ansible_os_family }}-{{ ansible_architecture }}.yml"
-  when: "'{{ ansible_os_family }}' == 'RedHat'"
+  include_tasks: "variables.yml"
 
 # Install our needed packages for each specific OS
 - include: "packages-{{ ansible_os_family }}.yml"
@@ -32,20 +27,18 @@
 # Sync our plugins
 - name: Install global plugins
   copy: >
-    src="{{ item }}"
-    dest="{{ nagios_nrpe_server_plugins_dir }}/"
+    src="{{ nagios_nrpe_server_plugins_src_dir }}/global/"
+    dest="{{ nagios_nrpe_server_plugins_dir }}"
     owner=root group=root mode=0755
-  with_fileglob:
-    - plugins/global/*
-
+  failed_when: false
+  
 # Install per-server plugins
 - name: Install per-server plugins
   copy: >
-    src="{{ item }}"
-    dest="{{ nagios_nrpe_server_plugins_dir }}/"
+    src="{{ nagios_nrpe_server_plugins_src_dir }}/{{ inventory_hostname }}/"
+    dest="{{ nagios_nrpe_server_plugins_dir }}"
     owner=root group=root mode=0755
-  with_fileglob:
-    - "plugins/{{ ansible_fqdn }}/*"
+  failed_when: false
 
 # Ensure NRPE server is running and will start at boot
 - name: Ensure NRPE server is running

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,0 +1,17 @@
+---
+# Variable configuration.
+- name: Include OS-specific variables.
+  include_vars: "{{ ansible_os_family }}.yml"
+  
+- name: Include OS-specific variables (RedHat).
+  include_vars: "{{ ansible_os_family }}-{{ ansible_architecture }}.yml"
+  when: ansible_os_family == 'RedHat'
+
+- name: Set defaults for OS-specific variables
+  set_fact:
+    nagios_nrpe_server_pid: "{{ nagios_nrpe_server_pid | default(__nagios_nrpe_server_pid) }}"
+    nagios_nrpe_server_user: "{{ nagios_nrpe_server_user | default(__nagios_nrpe_server_user) }}"
+    nagios_nrpe_server_group: "{{ nagios_nrpe_server_group | default(__nagios_nrpe_server_group) }}"
+    nagios_nrpe_server_service: "{{ nagios_nrpe_server_service | default(__nagios_nrpe_server_service) }}"
+    nagios_nrpe_server_plugins_dir: "{{ nagios_nrpe_server_plugins_dir | default(__nagios_nrpe_server_plugins_dir) }}"
+    nagios_nrpe_server_dir: "{{ nagios_nrpe_server_dir | default(__nagios_nrpe_server_dir) }}"

--- a/templates/nrpe_ansible.cfg.j2
+++ b/templates/nrpe_ansible.cfg.j2
@@ -1,11 +1,8 @@
-#################################
-# THIS FILE IS MANAGED BY ANSIBLE
-# DO NOT EDIT LOCALLY
-#################################
+# {{ ansible_managed }}
 
 # Command NRPE
 {% if nagios_nrpe_command is defined %}
 {% for command in nagios_nrpe_command %}
-command[{{ command }}]={{ nagios_nrpe_server_plugins_dir }}/{{ nagios_nrpe_command[command]["script"] }} {{ nagios_nrpe_command[command]["option"] }}
+command[{{ command }}]={{ nagios_nrpe_server_plugins_dir }}/{{ nagios_nrpe_command[command]["script"] | default('check_' + command) }} {{ nagios_nrpe_command[command]["option"] | default() }}
 {% endfor %}
 {% endif %}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,9 +1,9 @@
 ---
 # Arhclinux based OS variables
 
-nagios_nrpe_server_pid: /var/run/nrpe/nrpe.pid
-nagios_nrpe_server_user: 31
-nagios_nrpe_server_group: 31
-nagios_nrpe_server_service: nrpe
-nagios_nrpe_server_plugins_dir: /usr/lib/monitoring-plugins
-nagios_nrpe_server_dir: /etc/nrpe
+__nagios_nrpe_server_pid: /var/run/nrpe/nrpe.pid
+__nagios_nrpe_server_user: 31
+__nagios_nrpe_server_group: 31
+__nagios_nrpe_server_service: nrpe
+__nagios_nrpe_server_plugins_dir: /usr/lib/monitoring-plugins
+__nagios_nrpe_server_dir: /etc/nrpe

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,9 +3,9 @@
 # We're required to do this as the user/group NRPE is run under
 # differes between RedHat/Debian OS's
 
-nagios_nrpe_server_pid: /var/run/nagios/nrpe.pid
-nagios_nrpe_server_user: nagios
-nagios_nrpe_server_group: nagios
-nagios_nrpe_server_service: nagios-nrpe-server
-nagios_nrpe_server_plugins_dir: /usr/lib/nagios/plugins
-nagios_nrpe_server_dir: /etc/nagios
+__nagios_nrpe_server_pid: /var/run/nagios/nrpe.pid
+__nagios_nrpe_server_user: nagios
+__nagios_nrpe_server_group: nagios
+__nagios_nrpe_server_service: nagios-nrpe-server
+__nagios_nrpe_server_plugins_dir: /usr/lib/nagios/plugins
+__nagios_nrpe_server_dir: /etc/nagios

--- a/vars/RedHat-i386.yml
+++ b/vars/RedHat-i386.yml
@@ -1,1 +1,1 @@
-nagios_nrpe_server_plugins_dir: /usr/lib/nagios/plugins
+__nagios_nrpe_server_plugins_dir: /usr/lib/nagios/plugins

--- a/vars/RedHat-x86_64.yml
+++ b/vars/RedHat-x86_64.yml
@@ -1,1 +1,1 @@
-nagios_nrpe_server_plugins_dir: /usr/lib64/nagios/plugins
+__nagios_nrpe_server_plugins_dir: /usr/lib64/nagios/plugins

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,8 +3,8 @@
 # We're required to do this as the user/group NRPE is run under
 # differes between RedHat/Debian OS's
 
-nagios_nrpe_server_pid: /var/run/nrpe/nrpe.pid
-nagios_nrpe_server_user: nrpe
-nagios_nrpe_server_group: nrpe
-nagios_nrpe_server_service: nrpe
-nagios_nrpe_server_dir: /etc/nagios
+__nagios_nrpe_server_pid: /var/run/nrpe/nrpe.pid
+__nagios_nrpe_server_user: nrpe
+__nagios_nrpe_server_group: nrpe
+__nagios_nrpe_server_service: nrpe
+__nagios_nrpe_server_dir: /etc/nagios

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -1,7 +1,7 @@
-nagios_nrpe_server_dir: /etc/opt/csw
-nagios_nrpe_server_group: nagios
-nagios_nrpe_server_pid: /var/run/nrpe.pid
-nagios_nrpe_server_plugins_dir: /opt/csw/libexec/nagios-plugins
-nagios_nrpe_server_service: svc:/network/cswnrpe:default
-nagios_nrpe_server_user: nagios
+__nagios_nrpe_server_dir: /etc/opt/csw
+__nagios_nrpe_server_group: nagios
+__nagios_nrpe_server_pid: /var/run/nrpe.pid
+__nagios_nrpe_server_plugins_dir: /opt/csw/libexec/nagios-plugins
+__nagios_nrpe_server_service: svc:/network/cswnrpe:default
+__nagios_nrpe_server_user: nagios
 


### PR DESCRIPTION
Fixes #18 

Avoids warning printed when server-specific nrpe plugins directory doesn't exist.
Avoids looping with the copy module when recursive copy works fine.

Allows `nagios_nrpe_server_plugins_src_dir` to be overridden so this is useful when deploying module from galaxy.
